### PR TITLE
[version] Bump to 0.44.3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
       DOCKER_USERNAME: ${{ github.repository_owner }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_TARGET_PLATFORM: linux/arm/v8
-      METABASE_VERSION: v0.35.4
+      METABASE_VERSION: v0.44.3
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,5 +43,5 @@ jobs:
           --platform ${{ steps.prepare.outputs.docker_platform }} \
           --tag ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }} \
           --file ./Dockerfile \
-          --build-arg ${METABASE_VERSION} \
+          --build-arg METABASE_VERSION=${METABASE_VERSION} \
           --output type=image,push=$push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 ARG METABASE_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update -yq && apt-get install -yq bash fonts-dejavu-core fonts-dejav
 WORKDIR /app
 
 # copy app from the offical image
-COPY --from=metabase/metabase:v0.35.4 /app /app
+COPY --from=metabase/metabase:v0.44.3 /app /app
 
 # Make sure the build-arg METABASE_VERSION matches what's in the COPY command
 # above, since we can't use build-args in a COPY command.


### PR DESCRIPTION
## Short description of the changes

Upgrades metabase to 0.44.3.

## How to verify that this has the expected result

We don't actually push images for branches, so I built this locally:

```sh
docker buildx build \
    --platform linux/arm/v8 \
    --tag metabase:v0.44.3 \
    --file ./Dockerfile \
    --build-arg METABASE_VERSION=v0.44.3 \
    .
```

I then ran it 

```sh
docker run -d -p 3000:3000 --name metabase docker.io/library/metabase:v0.44.3
```

And verified that the image came up.

## deploying this

As far as rollout goes - this is a pretty big jump. Our database has backups done daily, and for the amount of data we have in metabase I feel like that's sufficient. If we want to be careful we can do a manual snapshot though.

