### PR TITLE
upgrade to 0.46.6.2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
       DOCKER_USERNAME: ${{ github.repository_owner }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_TARGET_PLATFORM: linux/arm/v8
-      METABASE_VERSION: v0.46.6.1
+      METABASE_VERSION: v0.46.6.2
     steps:
     - name: Checkout the code
       uses: actions/checkout@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update -yq && apt-get install -yq bash fonts-dejavu-core fonts-dejav
 WORKDIR /app
 
 # copy app from the offical image
-COPY --from=metabase/metabase:v0.46.6.1 /app /app
+COPY --from=metabase/metabase:v0.46.6.2 /app /app
 
 # Make sure the build-arg METABASE_VERSION matches what's in the COPY command
 # above, since we can't use build-args in a COPY command.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Upgrades Metabase to v0.46.6.2.

## Short description of the changes

(stolen from #3 - did these same commands and they worked)

We don't actually push images for branches, so I built this locally:
```
docker buildx build \
    --platform linux/arm/v8 \
    --tag metabase:v0.46.6.2 \
    --file ./Dockerfile \
    --build-arg METABASE_VERSION=v0.46.6.2 \
    .
```
I then ran it
```
docker run -d -p 3000:3000 --name metabase docker.io/library/metabase:v0.46.6.2
```
And verified that the image came up.

## How to verify that this has the expected result

We'll need to check to make sure pod comes up and we can access the UI; if we end up needing to roll back, the database has backups done hourly or so. (though I personally would not know how to do that)